### PR TITLE
Update GitHub Actions dependencies and cache configuration

### DIFF
--- a/.github/workflows/pull-request-lint.yml
+++ b/.github/workflows/pull-request-lint.yml
@@ -19,27 +19,29 @@ jobs:
       packages: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
         with:
           ref: "refs/pull/${{ github.event.pull_request.number }}/merge"
 
       - name: Validate Gradle Wrapper
-        uses: gradle/actions/wrapper-validation@v3
+        uses: gradle/actions/setup-gradle@94baf225fe0a508e581a564467443d0e2379123b # v4.3.0
 
-      - uses: actions/cache@v3
+      - uses: actions/cache@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
         with:
           path: |
-            ~/.konan
-          key: ${{ runner.os }}-${{ hashFiles('**/.lock') }}
+            ~/.gradle/caches
+            ~/.gradle/configuration-cache
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*') }}
 
       - name: Set up JDK 17
-        uses: actions/setup-java@v4
+        uses: actions/setup-java@3a4f6e1af504cf6a31855fa899c6aa5355ba6c12 # v4.7.0
         with:
           java-version: '17'
           distribution: 'temurin'
 
       - name: Setup ReviewDog
-        uses: reviewdog/action-setup@v1.3.0
+        uses: reviewdog/action-setup@e04ffabe3898a0af8d0fb1af00c188831c4b5893 # v1.3.2
         with:
           reviewdog_version: latest
 


### PR DESCRIPTION
# Related links
- https://github.com/cookpad/engineering/issues/2467

# Why?
- CI で利用していた `reviewdog/setup` アクションがサプライチェーン攻撃により悪意あるコードが実行される危険性があることが判明した
- 対象バージョンは `@v1` のみであったためこのリポジトリが攻撃に晒されたわけではないが、サプライチェーン攻撃への防衛策として使用するアクションのコミットハッシュを安全なものに固定することにする

# How?
- 使用している各アクションのバージョンを固定しました
- ついでに、キャッシュ設定がおかしくなっていたため、正しく設定しなおしました

# Testing :mag:
- 使用しているアクションのバージョンは安全なものか
