### PR TITLE
Add contents write permission for documents deploying workflow

### DIFF
--- a/.github/workflows/deploy-documents.yml
+++ b/.github/workflows/deploy-documents.yml
@@ -10,7 +10,7 @@ jobs:
     name: Deploy documents
     runs-on: ubuntu-latest
     permissions:
-      contents: read
+      contents: write
       packages: write
     steps:
       - name: Checkout

--- a/.github/workflows/deploy-library.yml
+++ b/.github/workflows/deploy-library.yml
@@ -10,7 +10,7 @@ jobs:
     name: Release build and publish
     runs-on: macOS-latest
     permissions:
-      contents: write
+      contents: read
       packages: write
     env:
       ORG_GRADLE_PROJECT_mavenCentralUsername: ${{ secrets.MAVEN_CENTRAL_USERNAME }}


### PR DESCRIPTION
# Related links
- N/A

# Why?
- GitHub Pages へのデプロイに contents write のパーミッションが必要だったので付与します

# How?
- 付与しました

# Testing :mag:
- GitHub Pages へのデプロイが可能か
