### PR TITLE
Add request flush method

### DIFF
--- a/puree/src/androidUnitTest/kotlin/com/cookpad/puree/kmp/PureeLoggerTest.kt
+++ b/puree/src/androidUnitTest/kotlin/com/cookpad/puree/kmp/PureeLoggerTest.kt
@@ -112,7 +112,7 @@ class PureeLoggerTest : LifecycleCoroutineRule() {
 
         // Assert
         outputs.forEach { output ->
-            verify(output).flush()
+            verify(output).requestFlush()
         }
     }
 

--- a/puree/src/commonMain/kotlin/com/cookpad/puree/kmp/PureeLogger.kt
+++ b/puree/src/commonMain/kotlin/com/cookpad/puree/kmp/PureeLogger.kt
@@ -114,7 +114,7 @@ class PureeLogger internal constructor(
      */
     fun flush() {
         scope.launch {
-            bufferedOutputs.forEach { it.flush() }
+            bufferedOutputs.forEach { it.requestFlush() }
         }
     }
 


### PR DESCRIPTION
# Related links
- https://github.com/cookpad/engineering/issues/2389

# Why?
- https://github.com/cookpad/engineering/issues/2599

# How?
- `flush` メソッドをエラーハンドリングなしで外部に公開していることが原因でした
  - iOS では resume 時に flush を呼んでいる（puree-swift の sendBufferedLogs 相当）
- エラーハンドリングを施した `requestFlush` メソッドを作成し、これを公開する様に変更しました

# Testing :mag:
- 意図的に flush しても問題はないか
