### PR TITLE
Set iOS framework to Dynamic

### DIFF
--- a/build-logic/src/main/kotlin/primitive/kmp/KmpIosPlugin.kt
+++ b/build-logic/src/main/kotlin/primitive/kmp/KmpIosPlugin.kt
@@ -19,7 +19,7 @@ class KmpIosPlugin : Plugin<Project> {
                 ).forEach { iosTarget ->
                     iosTarget.binaries.framework {
                         baseName = "PureeKMP"
-                        isStatic = true
+                        isStatic = false
 
                         xcf.add(this)
                     }


### PR DESCRIPTION
# Related links
- https://github.com/cookpad/engineering/issues/2389

# Why?
- KMP ライブラリが静的ライブラリとして作成されていると、取り込んだ先の Swift Preview が動かなくなるという問題が発生するため修正する
- FYI: https://ckpd.slack.com/archives/C08GZ3X954Z/p1744718506893759
- FYI: https://youtrack.jetbrains.com/issue/KT-70158/KMP-SwiftUI-Preview-not-working-with-Xcode-16-beta

# How?
- 動的ライブラリへと変更しました
