### PR TITLE
Add excludeFromDefaults method to customize logging behavior

### DIFF
--- a/demo/src/main/java/com/cookpad/puree/demo/Puree.kt
+++ b/demo/src/main/java/com/cookpad/puree/demo/Puree.kt
@@ -34,6 +34,7 @@ object Puree {
             )
             .defaultOutput(LogcatOutput())
             .defaultFilter(AddTimeFilter())
+            .excludeFromDefaults(PeriodicLog::class)
             .build()
     }
 

--- a/puree/src/androidMain/kotlin/com/cookpad/puree/kmp/Puree.android.kt
+++ b/puree/src/androidMain/kotlin/com/cookpad/puree/kmp/Puree.android.kt
@@ -38,6 +38,7 @@ actual class Puree(
 
     private val defaultFilters: MutableList<PureeFilter> = mutableListOf()
     private val defaultOutputs: MutableList<PureeOutput> = mutableListOf()
+    private val excludeFromDefaults: MutableList<String> = mutableListOf()
     private val configuredLogs: MutableMap<String, Configuration> = mutableMapOf()
     private val outputIds: MutableSet<String> = mutableSetOf()
     private val bufferedOutputs: MutableList<PureeBufferedOutput> = mutableListOf()
@@ -76,6 +77,24 @@ actual class Puree(
         }
 
         defaultOutputs.addAll(outputs)
+        return this
+    }
+
+    /**
+     * Excludes the specified log types from the default filters and outputs.
+     *
+     * This method allows you to specify log types that should not inherit the default
+     * filters and outputs. This is useful for customizing the logging behavior for
+     * specific log types without affecting the global configuration.
+     *
+     * @param logTypes Variable number of Kotlin classes representing the log types to exclude from defaults
+     * @return This Puree instance for method chaining
+     */
+    fun excludeFromDefaults(vararg logTypes: KClass<out PureeLog>): Puree {
+        logTypes.forEach {
+            excludeFromDefaults.add(it.simpleName.orEmpty())
+        }
+
         return this
     }
 
@@ -142,6 +161,7 @@ actual class Puree(
             clock = clock,
             defaultFilters = defaultFilters,
             defaultOutputs = defaultOutputs,
+            excludeFromDefaults = excludeFromDefaults,
             registeredLogs = configuredLogs,
             bufferedOutputs = bufferedOutputs,
         )

--- a/puree/src/commonMain/kotlin/com/cookpad/puree/kmp/PureeLogger.kt
+++ b/puree/src/commonMain/kotlin/com/cookpad/puree/kmp/PureeLogger.kt
@@ -38,6 +38,7 @@ class PureeLogger internal constructor(
     private val clock: Clock,
     private val defaultFilters: List<PureeFilter>,
     private val defaultOutputs: List<PureeOutput>,
+    private val excludeFromDefaults: List<String>,
     private val registeredLogs: Map<String, Configuration>,
     private val bufferedOutputs: List<PureeBufferedOutput>,
 ) {
@@ -79,8 +80,10 @@ class PureeLogger internal constructor(
      */
     fun <T : PureeLog> postLog(log: T, platformClass: PlatformClass<T>) {
         val config = registeredLogs[platformClass.simpleName]
-        val filters = config?.filters.orEmpty() + defaultFilters
-        val outputs = config?.outputs.orEmpty() + defaultOutputs
+        val isExcludeFromDefaults = excludeFromDefaults.contains(platformClass.simpleName)
+
+        val filters = config?.filters.orEmpty() + defaultFilters.takeIf { !isExcludeFromDefaults }.orEmpty()
+        val outputs = config?.outputs.orEmpty() + defaultOutputs.takeIf { !isExcludeFromDefaults }.orEmpty()
 
         if (filters.isEmpty() && outputs.isEmpty()) {
             throw LogNotRegisteredException()

--- a/puree/src/iosMain/kotlin/com/cookpad/puree/kmp/Puree.ios.kt
+++ b/puree/src/iosMain/kotlin/com/cookpad/puree/kmp/Puree.ios.kt
@@ -39,6 +39,7 @@ actual class Puree(
 
     private val defaultFilters: MutableList<PureeFilter> = mutableListOf()
     private val defaultOutputs: MutableList<PureeOutput> = mutableListOf()
+    private val excludeFromDefaults: MutableList<String> = mutableListOf()
     private val configuredLogs: MutableMap<String, Configuration> = mutableMapOf()
     private val outputIds: MutableSet<String> = mutableSetOf()
     private val bufferedOutputs: MutableList<PureeBufferedOutput> = mutableListOf()
@@ -77,6 +78,24 @@ actual class Puree(
         }
 
         defaultOutputs.addAll(outputs)
+        return this
+    }
+
+    /**
+     * Excludes the specified log types from the default filters and outputs.
+     *
+     * This method allows you to specify log types that should not inherit the default
+     * filters and outputs set in the Puree instance. This is useful for customizing
+     * logging behavior for specific log types.
+     *
+     * @param logTypes NSArray of Objective-C classes representing the log types to exclude from defaults
+     * @return This Puree instance for method chaining
+     */
+    @OptIn(BetaInteropApi::class)
+    fun excludeFromDefaults(logTypes: NSArray): Puree {
+        logTypes.toList<ObjCClass>().forEach {
+            excludeFromDefaults.add(NSStringFromClass(it))
+        }
         return this
     }
 
@@ -156,6 +175,7 @@ actual class Puree(
             clock = clock,
             defaultFilters = defaultFilters,
             defaultOutputs = defaultOutputs,
+            excludeFromDefaults = excludeFromDefaults,
             registeredLogs = configuredLogs,
             bufferedOutputs = bufferedOutputs,
         )


### PR DESCRIPTION
# Related links
- https://github.com/cookpad/engineering/issues/2646

# Why?
- デフォルトの Filter / Output を適用しない様にするメソッドを作成します

# How?
- `excludeFromDefaults` を作成しました

# Testing :mag:
- `excludeFromDefaults` を適用した際に、デフォルトの Filter / Output が適用されなくなるかを確認してください。
