### PR TITLE
Add error handling to emit method in PureeLogger

### DIFF
--- a/build-logic/src/main/kotlin/primitive/kmp/KmpIosPlugin.kt
+++ b/build-logic/src/main/kotlin/primitive/kmp/KmpIosPlugin.kt
@@ -22,6 +22,7 @@ class KmpIosPlugin : Plugin<Project> {
                         isStatic = false
 
                         xcf.add(this)
+                        freeCompilerArgs += listOf("-Xadd-light-debug=enable")
                     }
                 }
             }

--- a/puree/src/commonMain/kotlin/com/cookpad/puree/kmp/output/PureeBufferedLog.kt
+++ b/puree/src/commonMain/kotlin/com/cookpad/puree/kmp/output/PureeBufferedLog.kt
@@ -25,7 +25,7 @@ data class PureeBufferedLog(
      *
      * This property contains the serialized representation of the original log object
      * that was posted to the logger. The serialization is typically performed by a
-     * [com.cookpad.puree.serializer.PureeLogSerializer] implementation.
+     * [com.cookpad.puree.kmp.serializer.PureeLogSerializer] implementation.
      */
     val log: JsonObject,
 )


### PR DESCRIPTION
# Related links
- https://ckpd.slack.com/archives/C08GZ3X954Z/p1748498875506269

# Why?
- iOS でクラッシュが発生しているので修正する

# How?
- クラッシュの原因ははっきりと分かりませんでしたが、Coroutine の Worker が Uncatched で落ちているので、try-catch を行ってなかった `PureeBufferedOutput.emit()` にエラーハンドリングを追加しました
  - ここでは DB への追加を行っていますが、例外 = emit の失敗なので、当該ログは DB を経由せずすぐに `flsuh` するようにします
- また、今後クラッシュログを読みやすくするために dSYM を生成して XCFramework に含めるようにします

# Testing :mag:
- 再現方法は分かりません...
