### PR TITLE
Add kotlinx.atomicfu plugin and integrate into logging mechanism

### DIFF
--- a/build-logic/build.gradle.kts
+++ b/build-logic/build.gradle.kts
@@ -20,6 +20,7 @@ kotlin {
 dependencies {
     implementation(libs.android.gradlePlugin)
     implementation(libs.kotlin.gradlePlugin)
+    implementation(libs.atomic.gradlePlugin)
     implementation(libs.room.gradlePlugin)
     implementation(libs.detekt.gradlePlugin)
     implementation(libs.maven.publish.gradlePlugin)

--- a/build-logic/src/main/kotlin/primitive/kmp/KmpCommonPlugin.kt
+++ b/build-logic/src/main/kotlin/primitive/kmp/KmpCommonPlugin.kt
@@ -11,6 +11,7 @@ class KmpCommonPlugin : Plugin<Project> {
         with(target) {
             with(pluginManager) {
                 apply("org.jetbrains.kotlin.multiplatform")
+                apply("org.jetbrains.kotlinx.atomicfu")
             }
 
             kotlin {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -10,6 +10,7 @@ plugins {
     // Kotlin
     alias(libs.plugins.kotlin.serialization) apply false
     alias(libs.plugins.kotlin.compose.compiler) apply false
+    alias(libs.plugins.kotlinx.atomicfu) apply false
 
     // Publishing
     id("cookpad.primitive.publish.nexus")

--- a/demo/src/main/java/com/cookpad/puree/demo/log/output/LogcatDebugBufferedOutput.kt
+++ b/demo/src/main/java/com/cookpad/puree/demo/log/output/LogcatDebugBufferedOutput.kt
@@ -2,10 +2,16 @@ package com.cookpad.puree.demo.log.output
 
 import android.util.Log
 import com.cookpad.puree.kmp.output.PureeBufferedOutput
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
 import kotlinx.serialization.json.JsonObject
 import kotlin.time.Duration.Companion.seconds
 
 class LogcatDebugBufferedOutput(uniqueId: String) : PureeBufferedOutput(uniqueId) {
+
+    val scope = CoroutineScope(SupervisorJob())
 
     init {
         flushInterval = 5.seconds
@@ -14,5 +20,10 @@ class LogcatDebugBufferedOutput(uniqueId: String) : PureeBufferedOutput(uniqueId
     override fun emit(logs: List<JsonObject>, onSuccess: () -> Unit, onFailed: (Throwable) -> Unit) {
         Log.d(this::class.java.simpleName, "Logs: $logs")
         onSuccess()
+
+        scope.launch {
+            delay(1000)
+            onSuccess()
+        }
     }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -19,6 +19,7 @@ kotlinxCoroutines = "1.10.1"
 kotlinxDatetime = "0.6.1"
 kotlinxSerializationJson = "1.8.1"
 kotlinxImmutable = "0.3.8"
+kotlinxAtomicfu = "0.28.0"
 
 # AndroidX
 androidxCore = "1.16.0"
@@ -63,6 +64,7 @@ android-library = { id = "com.android.library", version.ref = "gradle" }
 # Kotlin
 kotlin-compose-compiler = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "kotlin" }
 kotlin-serialization = { id = "org.jetbrains.kotlin.plugin.serialization", version.ref = "kotlin" }
+kotlinx-atomicfu = { id = "org.jetbrains.kotlinx.atomicfu", version.ref = "kotlinxAtomicfu" }
 ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }
 
 # Publishing
@@ -81,6 +83,7 @@ detekt = { id = "io.gitlab.arturbosch.detekt", version.ref = "detekt" }
 ## Dependency of the include build-logic
 android-gradlePlugin = { group = "com.android.tools.build", name = "gradle", version.ref = "gradle" }
 kotlin-gradlePlugin = { group = "org.jetbrains.kotlin", name = "kotlin-gradle-plugin", version.ref = "kotlin" }
+atomic-gradlePlugin = { group = "org.jetbrains.kotlinx", name = "atomicfu-gradle-plugin", version.ref = "kotlinxAtomicfu" }
 room-gradlePlugin = { group = "androidx.room", name = "room-gradle-plugin", version.ref = "androidxRoom" }
 detekt-gradlePlugin = { group = "io.gitlab.arturbosch.detekt", name = "detekt-gradle-plugin", version.ref = "detekt" }
 detekt-formatting = { group = "io.gitlab.arturbosch.detekt", name = "detekt-formatting", version.ref = "detekt" }
@@ -101,6 +104,7 @@ kotlinx-coroutines-test = { group = "org.jetbrains.kotlinx", name = "kotlinx-cor
 kotlinx-datetime = { group = "org.jetbrains.kotlinx", name = "kotlinx-datetime", version.ref = "kotlinxDatetime" }
 kotlinx-serialization-json = { group = "org.jetbrains.kotlinx", name = "kotlinx-serialization-json", version.ref = "kotlinxSerializationJson" }
 kotlinx-collections-immutable = { group = "org.jetbrains.kotlinx", name = "kotlinx-collections-immutable", version.ref = "kotlinxImmutable" }
+kotlinx-atomicfu = { group = "org.jetbrains.kotlinx", name = "atomicfu", version.ref = "kotlinxAtomicfu" }
 
 # AndroidX
 androidx-core = { module = "androidx.core:core-ktx", version.ref = "androidxCore" }
@@ -144,6 +148,7 @@ infra = [
     "kotlinx-datetime",
     "kotlinx-serialization-json",
     "kotlinx-collections-immutable",
+    "kotlinx-atomicfu",
     "napier",
 ]
 

--- a/puree/src/commonMain/kotlin/com/cookpad/puree/kmp/PureeLogger.kt
+++ b/puree/src/commonMain/kotlin/com/cookpad/puree/kmp/PureeLogger.kt
@@ -10,6 +10,7 @@ import com.cookpad.puree.kmp.store.PureeLogStore
 import com.cookpad.puree.kmp.type.PlatformClass
 import io.github.aakira.napier.Napier
 import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.CoroutineExceptionHandler
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.launch
@@ -42,7 +43,12 @@ class PureeLogger internal constructor(
     private val registeredLogs: Map<String, Configuration>,
     private val bufferedOutputs: List<PureeBufferedOutput>,
 ) {
-    private val scope = CoroutineScope(dispatcher + SupervisorJob())
+    private val scope = CoroutineScope(
+        dispatcher + SupervisorJob() + CoroutineExceptionHandler { _, t ->
+            Napier.e("Uncaught exception in Puree", t)
+        }
+    )
+
     private var isResumed = false
 
     init {

--- a/puree/src/commonMain/kotlin/com/cookpad/puree/kmp/PureeLogger.kt
+++ b/puree/src/commonMain/kotlin/com/cookpad/puree/kmp/PureeLogger.kt
@@ -46,7 +46,7 @@ class PureeLogger internal constructor(
     private val scope = CoroutineScope(
         dispatcher + SupervisorJob() + CoroutineExceptionHandler { _, t ->
             Napier.e("Uncaught exception in Puree", t)
-        }
+        },
     )
 
     private var isResumed = false

--- a/puree/src/commonMain/kotlin/com/cookpad/puree/kmp/output/PureeBufferedOutput.kt
+++ b/puree/src/commonMain/kotlin/com/cookpad/puree/kmp/output/PureeBufferedOutput.kt
@@ -107,9 +107,11 @@ abstract class PureeBufferedOutput(
         this.clock = clock
         nextFlush = clock.now() + flushInterval
         retryCount = 0
-        coroutineScope = CoroutineScope(coroutineContext + SupervisorJob(coroutineContext[Job]) + CoroutineExceptionHandler { _, t ->
-            Napier.e("Uncaught exception in Puree", t)
-        })
+        coroutineScope = CoroutineScope(
+            coroutineContext + SupervisorJob(coroutineContext[Job]) + CoroutineExceptionHandler { _, t ->
+                Napier.e("Uncaught exception in Puree", t)
+            },
+        )
     }
 
     /**

--- a/puree/src/commonMain/kotlin/com/cookpad/puree/kmp/output/PureeBufferedOutput.kt
+++ b/puree/src/commonMain/kotlin/com/cookpad/puree/kmp/output/PureeBufferedOutput.kt
@@ -4,6 +4,7 @@ import com.cookpad.puree.kmp.store.PureeLogStore
 import com.cookpad.puree.kmp.type.JsonObject
 import io.github.aakira.napier.Napier
 import kotlinx.atomicfu.atomic
+import kotlinx.coroutines.CoroutineExceptionHandler
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.SupervisorJob
@@ -106,7 +107,9 @@ abstract class PureeBufferedOutput(
         this.clock = clock
         nextFlush = clock.now() + flushInterval
         retryCount = 0
-        coroutineScope = CoroutineScope(coroutineContext + SupervisorJob(coroutineContext[Job]))
+        coroutineScope = CoroutineScope(coroutineContext + SupervisorJob(coroutineContext[Job]) + CoroutineExceptionHandler { _, t ->
+            Napier.e("Uncaught exception in Puree", t)
+        })
     }
 
     /**

--- a/puree/src/commonMain/kotlin/com/cookpad/puree/kmp/output/PureeBufferedOutput.kt
+++ b/puree/src/commonMain/kotlin/com/cookpad/puree/kmp/output/PureeBufferedOutput.kt
@@ -222,7 +222,6 @@ abstract class PureeBufferedOutput(
 
             fun tryFinish(block: () -> Unit) {
                 if (finished.compareAndSet(expect = false, update = true)) {
-                    Napier.v { "Finished flushing logs for output: $uniqueId" }
                     block()
                 } else {
                     Napier.w { "Flush already finished for output: $uniqueId" }


### PR DESCRIPTION
# Related links
- https://ckpd.slack.com/archives/C08GZ3X954Z/p1748498875506269

# Why?
- iOS でクラッシュが発生しているので修正する

# How?
- 以前の修正 https://github.com/cookpad/puree-kmp/pull/32 ではクラッシュは治らなかった
- 次点で「suspendCancellableCoroutine の continue が2回以上呼ばれてクラッシュ」の問題を修正する
  - Atomic Boolean を用いてスレッドセーフなフラグを建て、必ず1度のみ continue が呼ばれる様に変更しました
  - iOS 側でも複数回コールバックが呼ばれない様にする PR を出しています
    - https://github.com/cookpad/global-ios/pull/23315
- これは最終手段となりますが、coroutine context に `CoroutineExceptionHandler` を加えて例外を握り潰すように変更しました

# Testing :mag:
- `LogcatDebugBufferedOutput` で意図的にコールバックを複数回呼ぶ様にしています
