### PR TITLE
Upgrade Java and Kotlin compiler options to version 21

### DIFF
--- a/build-logic/src/main/kotlin/primitive/publish/MavenPublishPlugin.kt
+++ b/build-logic/src/main/kotlin/primitive/publish/MavenPublishPlugin.kt
@@ -5,7 +5,6 @@ import com.cookpad.puree.kmp.version
 import com.vanniktech.maven.publish.JavadocJar
 import com.vanniktech.maven.publish.KotlinMultiplatform
 import com.vanniktech.maven.publish.MavenPublishBaseExtension
-import com.vanniktech.maven.publish.SonatypeHost
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.kotlin.dsl.assign
@@ -68,7 +67,7 @@ class MavenPublishPlugin : Plugin<Project> {
     private fun Project.configureMavenPublish() {
         extensions.configure<MavenPublishBaseExtension> {
             configure(KotlinMultiplatform(javadocJar = JavadocJar.Dokka("dokkaGeneratePublicationHtml")))
-            publishToMavenCentral(SonatypeHost.CENTRAL_PORTAL, true)
+            publishToMavenCentral(true)
 
             val hasUserNameFromProject = project.hasProperty("mavenCentralUsername")
             val hasUserNameFromEnv = System.getenv("ORG_GRADLE_PROJECT_mavenCentralUsername") != null

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -9,10 +9,10 @@ targetSdk = "36"
 compileSdk = "36"
 
 # Gradle
-gradle = "8.12.0"
+gradle = "8.12.1"
 
 # Kotlin
-kotlin = "2.2.0"
+kotlin = "2.2.10"
 
 # KotlinX
 kotlinxCoroutines = "1.10.2"
@@ -22,25 +22,25 @@ kotlinxImmutable = "0.4.0"
 kotlinxAtomicfu = "0.29.0"
 
 # AndroidX
-androidxCore = "1.16.0"
+androidxCore = "1.17.0"
 androidxAppCompat = "1.7.1"
 androidxActivity = "1.10.1"
 androidxStartup = "1.2.0"
 androidxLifecycle = "2.9.2"
 androidxRoom = "2.7.2"
 androidxSqlite = "2.5.2"
-androidxCompose = "2025.07.00"
+androidxCompose = "2025.08.00"
 
 # KMP
 kmpLifecycle = "2.9.0-alpha05"
 
 # Google
-ksp = "2.2.0-2.0.2"
+ksp = "2.2.10-2.0.2"
 
 # Publishing
 dokka = "2.0.0"
 nexus-publish = "2.0.0"
-maven-publish = "0.30.0"
+maven-publish = "0.34.0"
 
 # Test
 junit = "4.13.2"


### PR DESCRIPTION
# Related links
- ops/3336

# Why?
- OSSRH がクローズされてしまったため、公開方式を Central Portal 経由に変更する

# How?
- Central Portal 経由に変更しました
  - CD で利用している公開のための secrets をアップデートしました
    - username と password（ユーザートークンから生成）を更新しました
    - 更新後の値は 1ppassword に保存してあります
- ライブラリのアップデートを行いました

# Testing :mag:
- 公開ロジックに問題はないか
